### PR TITLE
application.jsのHeaderを各Page下に移設

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -5,12 +5,12 @@ import { createRoot } from "react-dom/client";
 import Top from "./pages/Top";
 import { AuthRegister } from "./pages/AuthRegister";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
-import { Header } from "./templates/Header";
+/* import { Header } from "./templates/Header"; */
 
 const root = createRoot(document.getElementById("root"));
 root.render(
   <BrowserRouter>
-    <Header />
+    {/* <Header /> */} {/* application.jsにHeaderを入れるとレイアウトが崩れるので、一旦コメントアウト */}
     <Routes>
       <Route path="/" element={<Top />} />
       <Route exact path="/register" element={<AuthRegister />} />

--- a/app/javascript/pages/AuthRegister/index.tsx
+++ b/app/javascript/pages/AuthRegister/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Header } from "../../templates/Header";
 
 export const AuthRegister: React.FC = () => {
   const [formData, setFormData] = useState({
@@ -30,6 +31,7 @@ export const AuthRegister: React.FC = () => {
 
   return (
     <div className="l-container">
+      <Header />
       <div className="p-signup">
           <h1 className="p-signup__title">会員登録</h1>
           <p className="p-signup__description">下記の情報を入力して、「新規会員登録する」ボタンを押してください。</p>

--- a/app/javascript/pages/Top/index.tsx
+++ b/app/javascript/pages/Top/index.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 import { LoginForm } from '../../templates/LoginForm';
 import { H2Header } from '../../parts/H2Header';
+import { Header } from '../../templates/Header';
 
 const Top: React.FC = () => {
   return (
     <div className="l-container">
+      <Header />
         <div className="p-top">
           <H2Header>会員ログイン</H2Header>
           <p className="p-top__description">メールアドレスとパスワードを入力して「ログイン」ボタンを押してください。</p>

--- a/app/javascript/templates/LoginForm/index.tsx
+++ b/app/javascript/templates/LoginForm/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Button } from '../../parts/Button';
 import { H3Header } from '../../parts/H3Header';
+import { Header } from '../../templates/Header';
 
 export const LoginForm: React.FC = () => {
   return (


### PR DESCRIPTION
# issue(対応しているissueを貼る！)

【認証機能】ログイン機能_フロント #17

# 概要
  - application.jsにimportされているHeaderをTopページと会員登録ページに移設した

# 変えたこと・実装内容
 - application.jsのHeaderをコメントアウトしTopページと会員登録ページに移設

# 確認したこと
- ローカル環境での確認 : (○)
  - 何を確認した？
    - Topページと新規登録ページのヘッダーのレイアウトが変になっていないこと
- 開発環境での確認 : (×)
- ユニットテストの実装 : (×)

# 変えたドキュメント(あれば)