### PR TITLE
アカウント登録 #6 (backend)

### DIFF
--- a/app/assets/stylesheets/pages/AuthRegister/_style.scss
+++ b/app/assets/stylesheets/pages/AuthRegister/_style.scss
@@ -26,7 +26,6 @@
     input[type="email"],
     input[type="radio"],
     input[type="tel"],
-    input[type="select"],
     input[type="password"] {
       padding: 0.5rem 0.5rem;
       margin-bottom: 1.5rem;
@@ -34,6 +33,20 @@
       border: 1px solid gray;
       border-radius: 4px;
       text-align: left;
+    }
+
+    select {
+      padding: 0.5rem 0.5rem;
+      margin-bottom: 1.5rem;
+      background-color: white;
+      border: 1px solid gray;
+      border-radius: 4px;
+      text-align: left;
+      appearance: menulist;
+      box-shadow: none;
+      font-size: 0.8rem;
+      text-overflow: ellipsis;
+      cursor: pointer;
     }
 
     button {
@@ -84,21 +97,6 @@
         color: red;
         font-weight: 600;
         font-size: 0.8rem;
-      }
-    }
-
-    &--address-block {
-      display: flex;
-      width: 100%;
-
-      &--prefecture {
-        flex: 0 0 40%; // 40%の幅を取る
-        // flex-shrink: 0;
-      }
-
-      &--city {
-        flex-grow: 1;
-        flex: 0 0 60%; // 60%の幅を取る
       }
     }
   }

--- a/app/controllers/v1/auth/registrations_controller.rb
+++ b/app/controllers/v1/auth/registrations_controller.rb
@@ -2,6 +2,7 @@ module V1
   module Auth
     class RegistrationsController < DeviseTokenAuth::RegistrationsController
       private
+
       def sign_up_params
         params.permit(:email, :password, :password_confirmation, :user_name, :user_type)
       end

--- a/app/controllers/v1/auth/registrations_controller.rb
+++ b/app/controllers/v1/auth/registrations_controller.rb
@@ -1,9 +1,7 @@
 module V1
   module Auth
     class RegistrationsController < DeviseTokenAuth::RegistrationsController
-
       private
-
       def sign_up_params
         params.permit(:email, :password, :password_confirmation, :user_name, :user_type)
       end

--- a/app/controllers/v1/auth/registrations_controller.rb
+++ b/app/controllers/v1/auth/registrations_controller.rb
@@ -1,5 +1,7 @@
 module V1
   module Auth
+    # RegistrationsController はユーザー登録処理を担うコントローラ
+    # DeviseTokenAuth gemを拡張して、特定の登録パラメータを許可
     class RegistrationsController < DeviseTokenAuth::RegistrationsController
       private
 

--- a/app/controllers/v1/auth/registrations_controller.rb
+++ b/app/controllers/v1/auth/registrations_controller.rb
@@ -1,6 +1,12 @@
 module V1
   module Auth
     class RegistrationsController < DeviseTokenAuth::RegistrationsController
+
+      private
+
+      def sign_up_params
+        params.permit(:email, :password, :password_confirmation, :user_name, :user_type)
+      end
     end
   end
 end

--- a/app/javascript/pages/AuthRegister/index.tsx
+++ b/app/javascript/pages/AuthRegister/index.tsx
@@ -31,8 +31,13 @@ export const AuthRegister: React.FC = () => {
         },
         body: JSON.stringify(data),
       });
-      const responseData = await response.json();
-      console.log(responseData);
+
+      if (response.ok) {
+        const responseData = await response.json();
+        localStorage.setItem('authToken', responseData.token);
+      } else {
+        throw new Error("サーバーエラーが発生しました。再度お試しください。");
+      }
     } catch (err) {
       console.log(err);
     }

--- a/app/javascript/pages/AuthRegister/index.tsx
+++ b/app/javascript/pages/AuthRegister/index.tsx
@@ -22,19 +22,28 @@ export const AuthRegister: React.FC = () => {
   });
 
   const onSubmit: SubmitHandler<Inputs> = async (data) => {
-    console.log(data);
     try {
       const response = await fetch("http://localhost:3000/v1/auth", {
         method: "POST",
         headers: {
           "Content-Type": "application/json"
         },
-        body: JSON.stringify(data),
+
+        body: JSON.stringify({
+          email: data.email,
+          password: data.password,
+          password_confirmation: data.passwordConfirmation,
+          user_name: data.username,
+          user_type: data.userType
+        }),
       });
 
       if (response.ok) {
-        const responseData = await response.json();
-        localStorage.setItem('authToken', responseData.token);
+        const accessToken = response.headers.get('access-token');
+        if (accessToken) {
+          localStorage.setItem('authToken', accessToken);
+        }
+
       } else {
         throw new Error("サーバーエラーが発生しました。再度お試しください。");
       }

--- a/app/javascript/pages/AuthRegister/index.tsx
+++ b/app/javascript/pages/AuthRegister/index.tsx
@@ -76,13 +76,13 @@ export const AuthRegister: React.FC = () => {
             <label htmlFor="username">ユーザー名</label>
             {errors.username?.message && <span>{errors.username.message}</span>}
           </div>
-          <input type="text" {...register("username", { required: "ユーザー名は必須です。" })} />
+          <input type="text" name="username" ref={register({ required: "ユーザー名は必須です。" })} />
 
           <div className="p-signup__form--label-with-validation-message">
             <label htmlFor="email">メールアドレス</label>
             {errors.email?.message && <span>{errors.email.message}</span>}
           </div>
-          <input type="email" {...register("email", {
+          <input type="email" name="email" ref={register({
             required: "メールアドレスは必須です。", pattern: {
               value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
               message: '無効なEメールアドレスです。'
@@ -93,7 +93,7 @@ export const AuthRegister: React.FC = () => {
             <label htmlFor="password">パスワード</label>
             {errors.password?.message && <span>{errors.password.message}</span>}
           </div>
-          <input type="password" {...register("password", {
+          <input type="password" name="password" ref={register({
             required: "パスワードは必須です。",
             minLength: { value: 6, message: "パスワードは6文字以上入力してください。" }
           })} />
@@ -102,7 +102,7 @@ export const AuthRegister: React.FC = () => {
             <label htmlFor="passwordConfirmation">確認のため再度入力してください</label>
             {errors.passwordConfirmation?.message && <span>{errors.passwordConfirmation.message}</span>}
           </div>
-          <input type="password" {...register("passwordConfirmation", {
+          <input type="password" name="passwordConfirmation" ref={register({
             required: "パスワードを再度入力してください。",
             validate: (value: string) => value === watch("password") || "パスワードが一致しません。"
           })} />
@@ -112,56 +112,57 @@ export const AuthRegister: React.FC = () => {
             {errors.userType?.message && <span>{errors.userType.message}</span>}
           </div>
           <div className="p-signup__form--user-type">
-            <input type="radio" id="offerer" value={1}  {...register("userType", { required: "ユーザータイプを選択してください。" })} /><label htmlFor="offerer">募集者</label>
-            <input type="radio" id="seeker" value={2} {...register("userType", { required: "ユーザータイプを選択してください。" })} /><label htmlFor="seeker">応募者</label>
+            <input type="radio" id="offerer" value={1} name="userType" ref={register({ required: "ユーザータイプを選択してください。" })} /><label htmlFor="offerer">募集者</label>
+            <input type="radio" id="seeker" value={2} name="userType" ref={register({ required: "ユーザータイプを選択してください。" })} /><label htmlFor="seeker">応募者</label>
           </div>
 
           <div className="p-signup__form--label-with-validation-message">
             <label htmlFor="zipcode">郵便番号</label>
             {errors.zipcode?.message && <span>{errors.zipcode.message}</span>}
           </div>
-          <input type="text" {...register("zipcode", {
-            required: "郵便番号は必須です。",
-            pattern: { value: /^\d{7}$/, message: "有効な郵便番号7桁を半角入力してください (例: 1234567) " }
-          })} />
+          <input
+            type="text"
+            name="zipcode"
+            ref={register({
+              required: "郵便番号は必須です。",
+              pattern: { value: /^\d{7}$/, message: "有効な郵便番号7桁を半角入力してください (例: 1234567) " }
+            })} />
 
-          <div className="p-signup__form--address-block">
+          {/* <div className="p-signup__form--address-block"> */}
 
-            <div className="p-signup__form--prefecture">
-              <div className="p-signup__form--label-with-validation-message">
-                {/* <div className="p-signup__form--prefecture"> */}
-                <label htmlFor="prefecture">都道府県</label>
-                {errors.prefecture?.message && <span>{errors.prefecture.message}</span>}
-              </div>
-              <select {...register("prefecture", { required: "都道府県を選択してください。" })}>
-                <option value="">選択してください</option>
-                {prefectures.map((prefecture) => (
-                  <option value={prefecture} key={prefecture}>{prefecture}</option>
-                ))}
-              </select>
-            </div>
-
-            <div className="p-signup__form--city">
-              <div className="p-signup__form--label-with-validation-message">
-                <label htmlFor="city">市区町村</label>
-                {errors.city?.message && <span>{errors.city.message}</span>}
-              </div>
-              <input type="text" {...register("city", { required: "市区町村を入力してください。" })} />
-            </div>
-
+          {/* <div className="p-signup__form--prefecture"> */}
+          <div className="p-signup__form--label-with-validation-message">
+            {/* <div className="p-signup__form--prefecture"> */}
+            <label htmlFor="prefecture">都道府県</label>
+            {errors.prefecture?.message && <span>{errors.prefecture.message}</span>}
           </div>
+          <select name="prefecture" ref={register({ required: "都道府県を選択してください。" })}>
+            <option value="">選択してください</option>
+            {prefectures.map((prefecture) => (
+              <option value={prefecture} key={prefecture}>{prefecture}</option>
+            ))}
+          </select>
+          {/* </div> */}
+
+          {/* <div className="p-signup__form--city"> */}
+          <div className="p-signup__form--label-with-validation-message">
+            <label htmlFor="city">市区町村</label>
+            {errors.city?.message && <span>{errors.city.message}</span>}
+          </div>
+          <input type="text" name="city" ref={register({ required: "市区町村を入力してください。" })} />
+          {/* </div> */}
 
           <div className="p-signup__form--label-with-validation-message">
             <label htmlFor="block">番地・建物名など</label>
             {errors.block?.message && <span>{errors.block.message}</span>}
           </div>
-          <input type="text" {...register("block", { required: "番地や建物名を入力してください。" })} />
+          <input type="text" name="block" ref={register({ required: "番地や建物名を入力してください。" })} />
 
           <div className="p-signup__form--label-with-validation-message">
             <label htmlFor="phoneNumber">電話番号</label>
             {errors.phoneNumber?.message && <span>{errors.phoneNumber.message}</span>}
           </div>
-          <input type="tel" {...register("phoneNumber", {
+          <input type="tel" name="phoneNumber" ref={register({
             required: "電話番号は必須です。",
             pattern: { value: /^\d+$/, message: "電話番号は半角数字のみで入力してください。" }
           })} />

--- a/app/javascript/pages/AuthRegister/index.tsx
+++ b/app/javascript/pages/AuthRegister/index.tsx
@@ -1,6 +1,10 @@
-import { Header } from "../../templates/Header";
+import { useState } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+
+import { Header } from "../../templates/Header";
 import prefectures from "../../utility/prefecture";
+
 
 type Inputs = {
   username: string,
@@ -17,6 +21,8 @@ type Inputs = {
 }
 
 export const AuthRegister: React.FC = () => {
+  const navigate = useNavigate();
+  const [flashMessage, setFlashMessage] = useState<string>("");
   const { register, handleSubmit, watch, formState: { errors, isValid, isSubmitting } } = useForm<Inputs>({
     mode: "onBlur", // フォーカスが外れたらvalidationが走ってくれる
   });
@@ -39,9 +45,16 @@ export const AuthRegister: React.FC = () => {
       });
 
       if (response.ok) {
+        // レスポンスヘッダーからアクセストークンを取得
         const accessToken = response.headers.get('access-token');
+
         if (accessToken) {
+          // ローカルストレージにアクセストークンを保存
           localStorage.setItem('authToken', accessToken);
+          // フラッシュメッセージを表示
+          // setFlashMessage("会員登録が完了しました。");
+          // トップページへリダイレクト
+          navigate("/");
         }
 
       } else {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,6 @@
 Rails.application.routes.draw do
   namespace :v1 do
-    mount_devise_token_auth_for "User", at: "auth", controllers: {
-      registrations: "v1/auth/registrations"
-  }
+    mount_devise_token_auth_for "User", at: "auth", controllers: { registrations: "v1/auth/registrations" }
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :v1 do
     mount_devise_token_auth_for "User", at: "auth", controllers: {
-      registrations: "v1/auth/registrations",
+      registrations: "v1/auth/registrations"
   }
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   namespace :v1 do
-    mount_devise_token_auth_for "User", at: "auth"
+    mount_devise_token_auth_for "User", at: "auth", controllers: {
+      registrations: "v1/auth/registrations",
+  }
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "esbuild": "^0.19.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "6",
     "react-router-dom": "^6.21.1",
     "sass": "^1.69.6",
     "typescript": "^5.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,6 +295,11 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-hook-form@6:
+  version "6.15.8"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.15.8.tgz#725c139d308c431c4611e4b9d85a49f01cfc0e7a"
+  integrity sha512-prq82ofMbnRyj5wqDe8hsTRcdR25jQ+B8KtCS7BLCzjFHAwNuCjRwzPuP4eYLsEBjEIeYd6try+pdLdw0kPkpg==
+
 react-router-dom@^6.21.1:
   version "6.21.1"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.21.1.tgz#58b459d2fe1841388c95bb068f85128c45e27349"


### PR DESCRIPTION
# issue(対応しているissueを貼る！)
【認証機能】アカウント登録 #6 (backend)

# 概要
アカウント登録のバックエンド機能の一部を実装
react-hook-formのバージョン変更に伴いフロントエンドも若干修正

# 変えたこと・実装内容
- react-hook-form@v7からv6への変更
- バージョン変更に伴うフォーム要素の修正
- フォームのボタン要素から[http://localhost:3000/v1/authへのPOSTリクエストを送信し users tableにレコード追加
- localStorageにtokenを格納

# 確認したこと
- ローカル環境での確認 : (○)
  - 何を確認した？
    - フォームのボタンを押下してリクエストが正常に送信されること
    - リクエストが正常に処理されてレスポンスが返ってくること (Status 200)
    - ブラウザーのApplication tabからlocalStorageにauth tokenが格納されていること
    - ローカルDBのusers tableにレコードが追加されていること
- 開発環境での確認 : (○)
- ユニットテストの実装 : (×)

# 変えたドキュメント(あれば)