### PR TITLE
Feature/45

### DIFF
--- a/app/assets/stylesheets/pages/CatShow/_style.scss
+++ b/app/assets/stylesheets/pages/CatShow/_style.scss
@@ -1,0 +1,39 @@
+@use '../../utility/colors' as *;
+
+table {
+  width: 80%;
+  margin: 0 auto;
+  border-collapse: collapse;
+  background-color: $white;
+  border: 2px solid $black;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  
+  th, td {
+    padding: 15px;
+    text-align: left;
+  }
+  
+  th {
+    color: #333;
+  }
+  
+  td {
+    text-align: center;
+    
+    img {
+      display: block; /* 画像を中央寄せにする */
+      margin: 0 auto;
+      max-width: 100%;
+      height: auto;
+      border-radius: 10px;
+      box-shadow: 0 2px 4px $black;
+      transition: transform 0.2s ease-in-out;
+      
+      &:hover {
+        transform: scale(1.1);
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/pages/_pages.scss
+++ b/app/assets/stylesheets/pages/_pages.scss
@@ -2,4 +2,5 @@
 // フォルダ生やしたら適宜パスの追加
 @use "../pages/AuthLogin/style.scss" as AuthLogin;
 @use "../pages/AuthRegister/style.scss" as AuthRegister;
+@use "../pages/CatShow/style.scss" as CatShow;
 @use "../pages/Top/style.scss" as Top;

--- a/app/javascript/pages/AuthLogin/index.tsx
+++ b/app/javascript/pages/AuthLogin/index.tsx
@@ -33,13 +33,17 @@ export const AuthLogin: React.FC = () => {
 
       if (response.ok) {
         const access_token = response.headers.get('access-token');
+        const client = response.headers.get('client');
+        const uid = response.headers.get('uid');
         console.log(access_token)
         // const responseData = await response.json(); // JSONデータを取得
         // const token = responseData.token; // 'token' プロパティを取得
 
-        if (access_token) {
+        if (access_token && client && uid) {
           // セキュリティ上の注意: アクセストークンを安全に保存する他の手段を検討する
           localStorage.setItem('authToken', access_token);
+          localStorage.setItem('client', client);
+          localStorage.setItem('uid', uid);
           setFlashMessage('ログインしました。');
           navigate('/');
         }

--- a/app/javascript/pages/ShowCat/index.tsx
+++ b/app/javascript/pages/ShowCat/index.tsx
@@ -8,14 +8,15 @@ import { Button } from '../../parts/Button';
 
 const CatShow: React.FC = () => {
   // React RouterのuseParamsフックを使用して画面遷移前のパラメータから情報を取得
-  const { catId } = useParams<{ cat_id: string }>();
-  const { name } = useParams<{ name: string }>();
-  const { breed } = useParams<{ breed: string }>();
-  const { image } = useParams<{ image: string }>();
-  const { date_of_birth } = useParams<{ date_of_birth: string }>();
-  const { sex } = useParams<{ sex: string }>();
-  const { status } = useParams<{ status: string }>();
-  const { UserUid } = useParams<{ uid: string }>();
+  const { catId, name, breed, date_of_birth, sex, status, UserUid } = useParams<{
+    cat_id: string;
+    name: string;
+    breed: string;
+    date_of_birth: string;
+    sex: string;
+    status: string;
+    uid: string;
+  }>();
 
   // ローカルストレージからログインしているユーザーのUIDを取得
   const loginUserUid = localStorage.getItem('uid');
@@ -24,90 +25,69 @@ const CatShow: React.FC = () => {
   const isShowButton = loginUserUid === UserUid;
 
   // 性別が「0」の場合は「男の子」、性別が「1」の場合は「女の子」、それ以外の場合は「不明」と表示する
-  let genderText;
-  switch (sex) {
-    case '0':
-      genderText = '男の子';
-      break;
-    case '1':
-      genderText = '女の子';
-      break;
-    default:
-      genderText = '不明';
-  }
+  const genderText = sex === '0' ? '男の子' : sex === '1' ? '女の子' : '不明';
 
   // ステータスが「1」の場合は「募集中」、ステータスが「2」の場合は「お見合い中」、ステータスが「3」の場合は「里親決定」と表示する
-  let statusText;
-  switch (status) {
-    case '1':
-      statusText = '募集中';
-      break;
-    case '2':
-      statusText = 'お見合い中';
-      break;
-    case '3':
-      statusText = '里親決定';
-      break;
-    default:
-      statusText = '不明';
-  }
+  const statusText =
+    status === '1' ? '募集中' : status === '2' ? 'お見合い中' : status === '3' ? '里親決定' : '不明';
 
   return (
     <ContainerTemplate>
       <Header />
       <PageTemplate>
-        <H2Header>{name}</H2Header>
-        <p className="p-top__description">{/* ここに猫の説明などを表示する変数やデータを入れる */}</p>
+        <H2Header>{name}詳細</H2Header>
+        <p className="p-top__description">{name}の詳細ページ</p>
         <div className="p-top__container">
-          <table>
-            <tbody>
-              <tr>
-                <td>写真:</td>
-                <td>
-                  <img src="http://pj-5bucket.s3.ap-northeast-1.amazonaws.com/test-cat.png" alt="猫の写真" />
-                </td>
-              </tr>
-              <tr>
-                <td>猫のID:</td>
-                <td>{catId}</td>
-              </tr>
-              <tr>
-                <td>名前:</td>
-                <td>{name}</td>
-              </tr>
-              <tr>
-                <td>猫種:</td>
-                <td>{breed}</td>
-              </tr>
-              <tr>
-                <td>生年月日:</td>
-                <td>{date_of_birth}</td>
-              </tr>
-              <tr>
-                <td>雌雄:</td>
-                <td>{genderText}</td>
-              </tr>
-              <tr>
-                <td>募集ステータス:</td>
-                <td>{statusText}</td>
-              </tr>
-              <tr>
-                <td>募集者:</td>
-                <td>{UserUid}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <div className="t-login__button">
-          {/* ログインしているユーザーのUIDと猫のUIDが一致した場合にボタンを表示する */}
-          {isShowButton && (
-            <>
-              <Button>お見合い中に設定する</Button>
-              <Button>里親決定設定する</Button>
-            </>
-          )}
-          {/* ログインしているユーザーのUIDと猫のUIDが一致しない場合は応募ボタンを表示する */}
-          {!isShowButton && <Button>応募する</Button>}
+          <div className="t-form">
+            <table>
+              <tbody>
+                <tr>
+                  <td colSpan={2}>
+                    <img src="http://pj-5bucket.s3.ap-northeast-1.amazonaws.com/test-cat.png" alt="猫の写真" />
+                  </td>
+                </tr>
+                <tr>
+                  <td>猫のID:</td>
+                  <td>{catId}</td>
+                </tr>
+                <tr>
+                  <td>名前:</td>
+                  <td>{name}</td>
+                </tr>
+                <tr>
+                  <td>猫種:</td>
+                  <td>{breed}</td>
+                </tr>
+                <tr>
+                  <td>生年月日:</td>
+                  <td>{date_of_birth}</td>
+                </tr>
+                <tr>
+                  <td>雌雄:</td>
+                  <td>{genderText}</td>
+                </tr>
+                <tr>
+                  <td>募集ステータス:</td>
+                  <td>{statusText}</td>
+                </tr>
+                <tr>
+                  <td>募集者:</td>
+                  <td>{UserUid}</td>
+                </tr>
+              </tbody>
+            </table>
+            <div className="t-login__button">
+              {/* ログインしているユーザーのUIDと猫のUIDが一致した場合にボタンを表示する */}
+              {isShowButton && (
+                <>
+                  <Button>お見合い中に設定する</Button>
+                  <Button>里親決定設定する</Button>
+                </>
+              )}
+              {/* ログインしているユーザーのUIDと猫のUIDが一致しない場合は応募ボタンを表示する */}
+              {!isShowButton && <Button>応募する</Button>}
+            </div>
+          </div>
         </div>
       </PageTemplate>
     </ContainerTemplate>

--- a/app/javascript/pages/ShowCat/index.tsx
+++ b/app/javascript/pages/ShowCat/index.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { H2Header } from '../../parts/H2Header';
+import { Header } from '../../templates/Header';
+import { ContainerTemplate } from '../../templates/ContainerTemplate';
+import { PageTemplate } from '../../templates/PageTemplate';
+import { Button } from '../../parts/Button';
+
+const CatShow: React.FC = () => {
+  // React RouterのuseParamsフックを使用して画面遷移前のパラメータから情報を取得
+  const { catId } = useParams<{ cat_id: string }>();
+  const { name } = useParams<{ name: string }>();
+  const { breed } = useParams<{ breed: string }>();
+  const { image } = useParams<{ image: string }>();
+  const { date_of_birth } = useParams<{ date_of_birth: string }>();
+  const { sex } = useParams<{ sex: string }>();
+  const { status } = useParams<{ status: string }>();
+  const { UserUid } = useParams<{ uid: string }>();
+
+  // ローカルストレージからログインしているユーザーのUIDを取得
+  const loginUserUid = localStorage.getItem('uid');
+
+  // ログインしているユーザーのUIDと猫のUIDが一致した場合にボタンを表示する
+  const isShowButton = loginUserUid === UserUid;
+
+  // 性別が「0」の場合は「男の子」、性別が「1」の場合は「女の子」、それ以外の場合は「不明」と表示する
+  let genderText;
+  switch (sex) {
+    case '0':
+      genderText = '男の子';
+      break;
+    case '1':
+      genderText = '女の子';
+      break;
+    default:
+      genderText = '不明';
+  }
+
+  // ステータスが「1」の場合は「募集中」、ステータスが「2」の場合は「お見合い中」、ステータスが「3」の場合は「里親決定」と表示する
+  let statusText;
+  switch (status) {
+    case '1':
+      statusText = '募集中';
+      break;
+    case '2':
+      statusText = 'お見合い中';
+      break;
+    case '3':
+      statusText = '里親決定';
+      break;
+    default:
+      statusText = '不明';
+  }
+
+  return (
+    <ContainerTemplate>
+      <Header />
+      <PageTemplate>
+        <H2Header>{name}</H2Header>
+        <p className="p-top__description">{/* ここに猫の説明などを表示する変数やデータを入れる */}</p>
+        <div className="p-top__container">
+          <table>
+            <tbody>
+              <tr>
+                <td>写真:</td>
+                <td>
+                  <img src="http://pj-5bucket.s3.ap-northeast-1.amazonaws.com/test-cat.png" alt="猫の写真" />
+                </td>
+              </tr>
+              <tr>
+                <td>猫のID:</td>
+                <td>{catId}</td>
+              </tr>
+              <tr>
+                <td>名前:</td>
+                <td>{name}</td>
+              </tr>
+              <tr>
+                <td>猫種:</td>
+                <td>{breed}</td>
+              </tr>
+              <tr>
+                <td>生年月日:</td>
+                <td>{date_of_birth}</td>
+              </tr>
+              <tr>
+                <td>雌雄:</td>
+                <td>{genderText}</td>
+              </tr>
+              <tr>
+                <td>募集ステータス:</td>
+                <td>{statusText}</td>
+              </tr>
+              <tr>
+                <td>募集者:</td>
+                <td>{UserUid}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div className="t-login__button">
+          {/* ログインしているユーザーのUIDと猫のUIDが一致した場合にボタンを表示する */}
+          {isShowButton && (
+            <>
+              <Button>お見合い中に設定する</Button>
+              <Button>里親決定設定する</Button>
+            </>
+          )}
+          {/* ログインしているユーザーのUIDと猫のUIDが一致しない場合は応募ボタンを表示する */}
+          {!isShowButton && <Button>応募する</Button>}
+        </div>
+      </PageTemplate>
+    </ContainerTemplate>
+  );
+};
+
+export default CatShow;

--- a/app/javascript/templates/Header/index.tsx
+++ b/app/javascript/templates/Header/index.tsx
@@ -4,10 +4,14 @@ import { Link, useNavigate } from 'react-router-dom';
 export const Header: React.FC = () => {
   const navigate = useNavigate(); // ここで useNavigate を呼び出す
   const token = localStorage.getItem('authToken')
+  const client = localStorage.getItem('client')
+  const uid = localStorage.getItem('uid')
 
   // ログアウトボタンのクリックハンドラ
   const handleLogout = () => {
     localStorage.removeItem('authToken');
+    localStorage.removeItem('client');
+    localStorage.removeItem('uid');
     navigate('/'); // 既に定義された navigate を使用
   };
 


### PR DESCRIPTION
# issue(対応しているissueを貼る！)
　【猫詳細】猫詳細画面_フロントエンド #45
# 概要
　　猫一覧から猫の詳細を確認するページ
# 変えたこと・実装内容
　・新規に猫詳細ページを実装しました
　・LocalStrageのUidと猫登録者Uidを突合させて応募者ボタンの切り分け
　・前ページからのパラメータを受け取り詳細ページに記入
# 確認したこと
- ローカル環境での確認 : (○)
  - 何を確認した？
  - 画面のフロント側のデザイン
  - 実際にできていないのは
  - 　・パラメータを取得し表示内容が切り替わるところ
  - 　・imageのURLは本番から画像のURLを持ってきて表示させてます。実際は前画面からimageのパラメータを取得して表示させる。
- 開発環境での確認 : (×)
- ユニットテストの実装 : (×)

# 変えたドキュメント(あれば)

ルーティングの設定はしていないので開発で確認ようにTOPページで修正を確認しながら実装しました。画面にアクセスすると下記の画像のように表示されるかと思います。

![catshow](https://github.com/collaborative-2023-g3/pj-group3/assets/152865036/7150f075-e1dd-472a-886b-cedded7c5da3)
